### PR TITLE
chore: extend test timeout

### DIFF
--- a/test.ts
+++ b/test.ts
@@ -12,8 +12,8 @@ const runTest = async (width: number, depth: number) => {
     const page = await browser.newPage();
     await wait(500);
     const start = performance.now();
-    await page.goto(`http://localhost:5173`);
-    await page.waitForSelector("#app", { timeout: 10_000 });
+    await page.goto(`http://localhost:5173`, { timeout: 60_000 });
+    await page.waitForSelector("#app", { timeout: 60_000 });
     runs.push(Math.round(performance.now() - start));
     await page.close();
     process.kill();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vite";
 export default defineConfig({
   // server: {
   //   warmup: {
-  //     clientFiles: ['./src/**.ts']
+  //     clientFiles: ['./src/**/*.ts']
   //   }
   // },
   plugins: [


### PR DESCRIPTION
Extend `goto` and `waitForSelector` timeout to 60s. I find that sometimes it timeout-ed on my machine.

I also updated the warmup glob so that it works. Previously it wasn't capturing any files. From a brief test with `bun run test 20 20`:

No warmup:

```
400 TS modules (20x20) loaded in: 330ms (runs: [361,325,330,315,355])
```

Warmup:

```
400 TS modules (20x20) loaded in: 269ms (runs: [280,263,272,260,269])
```

For larger module sizes it didn't yield much difference as presumably it's warming up too many files (?). The config option tends to require a bit of fine tune